### PR TITLE
[FIX,TST] Fix math label in proof directive

### DIFF
--- a/sphinxcontrib/_static/proof.css
+++ b/sphinxcontrib/_static/proof.css
@@ -42,6 +42,7 @@ div#proof{
 	padding: .6rem .8rem !important;
 	border-left: .2rem solid var(--warning-border-color);
 	background-color: var(--warning-title-color);
+	font-style: italic;
 }
 
 /*********************************************

--- a/sphinxcontrib/prettyproof/directive.py
+++ b/sphinxcontrib/prettyproof/directive.py
@@ -79,6 +79,7 @@ class ElementDirective(SphinxDirective):
         else:
             node = enumerable_node()
 
+        node.document = self.state.document
         node += nodes.title(title_text, "", *textnodes)
         node += section
 
@@ -104,17 +105,16 @@ class ElementDirective(SphinxDirective):
 class ProofDirective(SphinxDirective):
     """ A custom directive for proofs """
 
-    name = ""
+    name = "proof"
     has_content = True
     required_arguments = 0
-    optional_arguments = 1
+    optional_arguments = 0
     final_argument_whitespace = True
     option_spec = {
         "class": directives.class_option,
     }
 
     def run(self) -> List[Node]:
-        env = self.env
         content = ViewList()
         domain_name, typ = self.name.split(":")[0], self.name.split(":")[1]
 
@@ -124,17 +124,11 @@ class ProofDirective(SphinxDirective):
             classes.extend(class_name)
 
         section = nodes.admonition(classes=classes, ids=[typ])
-        emph = nodes.emphasis()
-
-        if self.arguments != []:
-            content.append(self.arguments[0], 0)
-            self.content.insert(0, content)
 
         self.content[0] = "{}. ".format(typ.title()) + self.content[0]
-        self.state.nested_parse(self.content, self.content_offset, emph)
+        self.state.nested_parse(self.content, 0, section)
 
         node = proof_node()
-        section += emph
         node += section
 
         return [node]

--- a/tests/books/mybook/index.rst
+++ b/tests/books/mybook/index.rst
@@ -10,4 +10,7 @@ A Test Program!
    algorithm/_algo_numbered_reference
    algorithm/_algo_text_reference
    proof/_proof_with_classname
+   proof/_proof_with_labeled_math
    proof/_proof_no_classname
+   proof/_proof_with_unlabeled_math
+   proof/_proof_with_argument_content

--- a/tests/books/mybook/proof/_proof_no_classname.rst
+++ b/tests/books/mybook/proof/_proof_no_classname.rst
@@ -3,6 +3,9 @@ content 2
 
 .. proof:proof::
 
-	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 
-	Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+

--- a/tests/books/mybook/proof/_proof_with_argument_content.rst
+++ b/tests/books/mybook/proof/_proof_with_argument_content.rst
@@ -1,0 +1,7 @@
+content 5
+=========
+
+.. proof:proof:: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/books/mybook/proof/_proof_with_classname.rst
+++ b/tests/books/mybook/proof/_proof_with_classname.rst
@@ -2,6 +2,6 @@ content 1
 =========
 
 .. proof:proof::
-	:class: test-proof
+    :class: test-proof
 
-	Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/books/mybook/proof/_proof_with_labeled_math.rst
+++ b/tests/books/mybook/proof/_proof_with_labeled_math.rst
@@ -1,0 +1,11 @@
+content 4
+=========
+
+.. proof:proof::
+
+   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+
+   .. math::
+      :label: label1
+
+      P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)

--- a/tests/books/mybook/proof/_proof_with_unlabeled_math.rst
+++ b/tests/books/mybook/proof/_proof_with_unlabeled_math.rst
@@ -1,0 +1,10 @@
+content 3
+=========
+
+.. proof:proof::
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+
+    .. math::
+
+        P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)

--- a/tests/test_proof.py
+++ b/tests/test_proof.py
@@ -34,6 +34,9 @@ def test_proof(tmpdir, file_regression):
     proof_list = [
         "_proof_with_classname.rst",
         "_proof_no_classname.rst",
+        "_proof_with_argument_content.rst",
+        "_proof_with_labeled_math.rst",
+        "_proof_with_unlabeled_math.rst",
     ]
 
     for idir in proof_list:

--- a/tests/test_proof/_proof_no_classname.html
+++ b/tests/test_proof/_proof_no_classname.html
@@ -1,4 +1,5 @@
 <div class="proof admonition" id="proof">
-<em><p>Proof. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+<p>Proof. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
 <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-</em></div>
+</div>

--- a/tests/test_proof/_proof_with_argument_content.html
+++ b/tests/test_proof/_proof_with_argument_content.html
@@ -1,0 +1,5 @@
+<div class="proof admonition" id="proof">
+<p>Proof. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</div>

--- a/tests/test_proof/_proof_with_classname.html
+++ b/tests/test_proof/_proof_with_classname.html
@@ -1,3 +1,3 @@
 <div class="proof test-proof admonition" id="proof">
-<em><p>Proof. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-</em></div>
+<p>Proof. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</div>

--- a/tests/test_proof/_proof_with_labeled_math.html
+++ b/tests/test_proof/_proof_with_labeled_math.html
@@ -1,0 +1,5 @@
+<div class="proof admonition" id="proof">
+<p>Proof. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut</p>
+<div class="math notranslate nohighlight" id="equation-label1">
+<span class="eqno">(1)<a class="headerlink" href="#equation-label1" title="Permalink to this equation">¶</a></span>\[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>
+</div>

--- a/tests/test_proof/_proof_with_unlabeled_math.html
+++ b/tests/test_proof/_proof_with_unlabeled_math.html
@@ -1,0 +1,5 @@
+<div class="proof admonition" id="proof">
+<p>Proof. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut</p>
+<div class="math notranslate nohighlight">
+\[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>
+</div>


### PR DESCRIPTION
This PR fixes the `list index out of range` error thrown when a `proof:proof` directive includes a `math` directive with a label (#2).

New test cases have been included:
* **_proof_with_labeled_math**: example of `proof:proof` directive which includes a labeled `math` directive
* **_proof_with_labeled_math**: simple example of `proof:proof` directive which includes a `math` directive (no label)
* **_proof_with_argument_content**: example of a `proof:proof` directive that require no arguments

In addition to that, `nodes.emphasis()` has been replaced with the CSS font-style.