### PR TITLE
[STY] Update style of proof directive

### DIFF
--- a/sphinxcontrib/_static/proof.css
+++ b/sphinxcontrib/_static/proof.css
@@ -40,8 +40,8 @@ div.proof p.admonition-title::before {
 *********************************************/
 div#proof{
 	padding: .6rem .8rem !important;
-	border-left: .2rem solid var(--warning-border-color);
-	background-color: var(--warning-title-color);
+	border-left: .2rem solid var(--grey-border-color);
+	background-color: none;
 	font-style: italic;
 }
 


### PR DESCRIPTION
This PR updates the style of a `proof` directive to include no background color and a light grey left border per @jstac suggestion.