### PR TITLE
📚 DOCS: Additional documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ extensions = ["sphinxcontrib.prettyproof"]
 See the [Sphinxcontrib Pretty Proof documentation](https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/) for more information.
 
 
+## Contributing
+
+We welcome all contributions! See the [EBP Contributing Guide](https://executablebooks.org/en/latest/contributing.html) for general details, and below for guidance specific to sphinxcontrib-prettyproof.
+
+
 [rtd-badge]: https://readthedocs.org/projects/sphinxcontrib-prettyproof/badge/?version=latest
 [rtd-link]: https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/?badge=latest
 [github-ci]: https://github.com/najuzilu/sphinxcontrib-prettyproof/workflows/continuous-integration/badge.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # sphinxcontrib-prettyproof
 
-[![Documentation Status](https://readthedocs.org/projects/sphinxcontrib-prettyproof/badge/?version=latest)](https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status][rtd-badge]][rtd-link]
+[![Github-CI][github-ci]][github-link]
+[![Coverage Status][codecov-badge]][codecov-link]
 
 **A proof extension for Sphinx**.
 
@@ -29,3 +31,11 @@ extensions = ["sphinxcontrib.prettyproof"]
 ## Documentation
 
 See the [Sphinxcontrib Pretty Proof documentation](https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/) for more information.
+
+
+[rtd-badge]: https://readthedocs.org/projects/sphinxcontrib-prettyproof/badge/?version=latest
+[rtd-link]: https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/?badge=latest
+[github-ci]: https://github.com/najuzilu/sphinxcontrib-prettyproof/workflows/continuous-integration/badge.svg?branch=master
+[github-link]: https://github.com/najuzilu/sphinxcontrib-prettyproof
+[codecov-badge]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -5,17 +5,21 @@
 
 install
 syntax
+contribute
 testing
 zreferences
 ```
 
-[![Documentation Status](https://readthedocs.org/projects/sphinxcontrib-prettyproof/badge/?version=latest)](https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status][rtd-badge]][rtd-link]
+[![Github-CI][github-ci]][github-link]
+[![Coverage Status][codecov-badge]][codecov-link]
 
 **A proof extension for Sphinx**.
 
 This package contains a [Sphinx](http://www.sphinx-doc.org/en/master/) extension
 for producing proof, theorem, axiom, lemma, definition, criterion, remark, conjecture,
 corollary, algorithm, exercise, example, property, observation and proposition directives.
+
 
 ```{warning}
 sphinxcontrib-prettyproof `0.0.2` is in a development stage and may change rapidly.
@@ -59,3 +63,11 @@ extensions = ["sphinxcontrib.prettyproof"]
 ```
 
 you may then build using `make html` and the extension will be used by your `Sphinx` project.
+
+
+[rtd-badge]: https://readthedocs.org/projects/sphinxcontrib-prettyproof/badge/?version=latest
+[rtd-link]: https://sphinxcontrib-prettyproof.readthedocs.io/en/latest/?badge=latest
+[github-ci]: https://github.com/najuzilu/sphinxcontrib-prettyproof/workflows/continuous-integration/badge.svg?branch=master
+[github-link]: https://github.com/najuzilu/sphinxcontrib-prettyproof
+[codecov-badge]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/najuzilu/sphinxcontrib-prettyproof

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -18,3 +18,14 @@ then run:
 ```bash
 python setup.py install
 ```
+
+## Package development
+
+To install `sphinxcontrib-prettyproof` for package development:
+
+```bash
+git clone https://github.com/najuzilu/sphinxcontrib-prettyproof
+cd sphinxcontrib-prettyproof
+git checkout master
+pip install -e .[all]
+```

--- a/docs/source/testing.md
+++ b/docs/source/testing.md
@@ -29,3 +29,23 @@ Sphinx Application API is available as a parameter to all the test functions:
 @pytest.mark.sphinx('html', testroot="mybook")
 def mytest(app):
 ```
+
+## Code Style
+
+Code is formatted using [black](https://github.com/ambv/black) and code style is tested using [flake8](http://flake8.pycqa.org) with style configuration set in `.flake8`.
+
+Installing using `[code style]` will make the [pre-commit](https://pre-commit.com/) package available which will make sure the style is met before your commits are submitted. In addition, it will reformat for any lint errors.
+
+To install `pre-commit` run the following
+
+```bash
+cd sphinxcontrib-prettyproof
+pre-commit install
+```
+
+`black` and `flake8` can be run separately:
+
+```shell
+>>> black .
+>>> flake8 .
+```


### PR DESCRIPTION
This PR adds the following:
- how to install `sphinxcontrib-prettyproof` for package development
- new icon+badges for github-ci and coverage status
- contributing documentation
- code style documentation