### PR TITLE
🐛 FIX: Singlehtml builder error when adding to another project.

### DIFF
--- a/sphinx_proof/__init__.py
+++ b/sphinx_proof/__init__.py
@@ -79,13 +79,11 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_domain(ProofDomain)
     app.add_node(
         proof_node,
-        singlehtml=(visit_proof_node, depart_proof_node),
         html=(visit_proof_node, depart_proof_node),
         latex=(visit_proof_node, depart_proof_node),
     )
     app.add_node(
         unenumerable_node,
-        singlehtml=(visit_unenumerable_node, depart_unenumerable_node),
         html=(visit_unenumerable_node, depart_unenumerable_node),
         latex=(visit_unenumerable_node, depart_unenumerable_node),
     )
@@ -94,7 +92,6 @@ def setup(app: Sphinx) -> Dict[str, Any]:
             NODE_TYPES[node],
             node,
             None,
-            singlehtml=(visit_enumerable_node, depart_enumerable_node),
             html=(visit_enumerable_node, depart_enumerable_node),
             latex=(visit_enumerable_node, depart_enumerable_node),
         )

--- a/sphinx_proof/nodes.py
+++ b/sphinx_proof/nodes.py
@@ -77,6 +77,7 @@ def depart_proof_node(self, node: Node) -> None:
 def get_node_number(self, node: Node, typ) -> str:
     """Get the number for the directive node for HTML."""
     ids = node.attributes.get("ids", [])[0]
+    key = typ
     if isinstance(self, LaTeXTranslator):
         docname = find_parent(self.builder.env, node, "section")
         fignumbers = self.builder.env.toc_fignumbers.get(
@@ -84,7 +85,9 @@ def get_node_number(self, node: Node, typ) -> str:
         )  # Latex does not have builder.fignumbers
     else:
         fignumbers = self.builder.fignumbers
-    number = fignumbers.get(typ, {}).get(ids, ())
+        if self.builder.name == "singlehtml":
+            key = "%s/%s" % (self.docnames[-1], typ)
+    number = fignumbers.get(key, {}).get(ids, ())
     return ".".join(map(str, number))
 
 


### PR DESCRIPTION
fixes https://github.com/executablebooks/sphinx-proof/issues/65 . 

Apparently adding a singlehtml handle for a node, breaks other project's node which don't handle singlehtml.

Also, the addition of integrating handling of searching fignumbers for singlehtml builders.