### PR TITLE
feat: Added possibility for shared numbering of theorems, fixing issue #64

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,4 +57,20 @@ proof_minimal_theme = False
 
 myst_enable_extensions = ["dollarmath", "amsmath"]
 
-proof_uniform_numbering = True
+prf_realtyp_to_countertyp = {
+    "axiom": "theorem",
+    "theorem": "theorem",
+    "lemma": "theorem",
+    "algorithm": "theorem",
+    "definition": "theorem",
+    "remark": "theorem",
+    "conjecture": "theorem",
+    "corollary": "theorem",
+    "criterion": "theorem",
+    "example": "theorem",
+    "property": "theorem",
+    "observation": "theorem",
+    "proposition": "theorem",
+    "assumption": "theorem",
+    "notation": "theorem",
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,20 +57,4 @@ proof_minimal_theme = False
 
 myst_enable_extensions = ["dollarmath", "amsmath"]
 
-prf_realtyp_to_countertyp = {
-    "axiom": "theorem",
-    "theorem": "theorem",
-    "lemma": "theorem",
-    "algorithm": "theorem",
-    "definition": "theorem",
-    "remark": "theorem",
-    "conjecture": "theorem",
-    "corollary": "theorem",
-    "criterion": "theorem",
-    "example": "theorem",
-    "property": "theorem",
-    "observation": "theorem",
-    "proposition": "theorem",
-    "assumption": "theorem",
-    "notation": "theorem",
-}
+prf_realtyp_to_countertyp = {}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,3 +56,5 @@ proof_minimal_theme = False
 # MyST Parser Configuration
 
 myst_enable_extensions = ["dollarmath", "amsmath"]
+
+proof_uniform_numbering = True

--- a/docs/source/options.md
+++ b/docs/source/options.md
@@ -84,4 +84,3 @@ prf_realtyp_to_countertyp = {
 ```
 The `lemma` and `theorem` directives share a counter, however the `conjecture` directive has a separate counter (the `lemma` counter which is **not** used by `lemma` directives).
 ````
-

--- a/docs/source/options.md
+++ b/docs/source/options.md
@@ -35,7 +35,7 @@ Add `proof_minimal_theme = True` to your `conf.py`
 ## Shared numbering
 
 By default, each type of theorem has their own numbering and counter.
-This can be changed to a common counter by setting the option `prf_realtyp_to_countertyp` to a dictionary associating to each prf-type which prf-type's counter it should use.
+This can be changed by setting the option `prf_realtyp_to_countertyp` to a dictionary associating to a prf-type which prf-type's counter it should use.
 
 ### Sphinx Project
 

--- a/docs/source/options.md
+++ b/docs/source/options.md
@@ -35,19 +35,31 @@ Add `proof_minimal_theme = True` to your `conf.py`
 ## Shared numbering
 
 By default, each type of theorem has their own numbering and counter.
-This can be changed to a common counter by setting the option `proof_uniform_numbering` to true.
+This can be changed to a common counter by setting the option `prf_realtyp_to_countertyp` to a dictionary associating to each prf-type which prf-type's counter it should use.
 
 ### Sphinx Project
 
-Add `proof_uniform_numbering = True` to your `conf.py`
+In `conf.py`, e.g. to have a shared counter for all prf-types:
 
-
-### Jupyter Book Project
-
-Add `proof_uniform_numbering = True` to your `_config.yml` (untested)
-
-```yaml
-sphinx:
-  config:
-    proof_uniform_numbering: true
 ```
+prf_realtyp_to_countertyp = {
+    "axiom": "theorem",
+    "theorem": "theorem",
+    "lemma": "theorem",
+    "algorithm": "theorem",
+    "definition": "theorem",
+    "remark": "theorem",
+    "conjecture": "theorem",
+    "corollary": "theorem",
+    "criterion": "theorem",
+    "example": "theorem",
+    "property": "theorem",
+    "observation": "theorem",
+    "proposition": "theorem",
+    "assumption": "theorem",
+    "notation": "theorem",
+}
+```
+
+
+

--- a/docs/source/options.md
+++ b/docs/source/options.md
@@ -76,11 +76,13 @@ prf_realtyp_to_countertyp = {
 
 ````{warning}
 The association of a counter to a directive is not transitive: Let us consider the following configuration:
+
 ```
 prf_realtyp_to_countertyp = {
     "lemma": "theorem",
     "conjecture": "lemma",
 }
 ```
+
 The `lemma` and `theorem` directives share a counter, however the `conjecture` directive has a separate counter (the `lemma` counter which is **not** used by `lemma` directives).
 ````

--- a/docs/source/options.md
+++ b/docs/source/options.md
@@ -60,6 +60,3 @@ prf_realtyp_to_countertyp = {
     "notation": "theorem",
 }
 ```
-
-
-

--- a/docs/source/options.md
+++ b/docs/source/options.md
@@ -34,12 +34,11 @@ Add `proof_minimal_theme = True` to your `conf.py`
 
 ## Shared numbering
 
-By default, each type of theorem has their own numbering and counter.
-This can be changed by setting the option `prf_realtyp_to_countertyp` to a dictionary associating to a prf-type which prf-type's counter it should use.
+By default, each type of (prf-)directive has their own numbering and counter. This can be changed by setting the option `prf_realtyp_to_countertyp` to a dictionary associating to a directive which the counter of which directive it should use.
 
 ### Sphinx Project
 
-In `conf.py`, e.g. to have a shared counter for all prf-types:
+In `conf.py`, e.g. to have a shared counter for all directives:
 
 ```
 prf_realtyp_to_countertyp = {
@@ -60,3 +59,29 @@ prf_realtyp_to_countertyp = {
     "notation": "theorem",
 }
 ```
+
+In the following case, the directives `lemma`, `conjecture`, `corollary` and `proposition` will share the counter with `theorem`, while `axiom` and `assumption` will share the counter with `definition`. All other directives would use their original counter.
+
+
+```
+prf_realtyp_to_countertyp = {
+    "lemma": "theorem",
+    "conjecture": "theorem",
+    "corollary": "theorem",
+    "proposition": "theorem",
+    "axiom": "definition",
+    "assumption": "definition",
+}
+```
+
+````{warning}
+The association of a counter to a directive is not transitive: Let us consider the following configuration:
+```
+prf_realtyp_to_countertyp = {
+    "lemma": "theorem",
+    "conjecture": "lemma",
+}
+```
+The `lemma` and `theorem` directives share a counter, however the `conjecture` directive has a separate counter (the `lemma` counter which is **not** used by `lemma` directives).
+````
+

--- a/docs/source/options.md
+++ b/docs/source/options.md
@@ -1,5 +1,7 @@
 # Options
 
+## Minimal color scheme
+
 This package has the option to choose a more **minimal** color scheme.
 
 The aim is to create admonitions that are clearly different to the core text with
@@ -15,7 +17,7 @@ compared to the current default
 
 To enable the `minimal` color scheme you can use the following.
 
-## Jupyter Book Project
+### Jupyter Book Project
 
 Add `proof_minimal_theme = True` to your `_config.yml`
 
@@ -25,6 +27,27 @@ sphinx:
     proof_minimal_theme: true
 ```
 
-## Sphinx Project
+### Sphinx Project
 
 Add `proof_minimal_theme = True` to your `conf.py`
+
+
+## Shared numbering 
+
+By default, each type of theorem has their own numbering and counter.
+This can be changed to a common counter by setting the option `proof_uniform_numbering` to true.
+
+### Sphinx Project
+
+Add `proof_uniform_numbering = True` to your `conf.py`
+
+
+### Jupyter Book Project
+
+Add `proof_uniform_numbering = True` to your `_config.yml` (untested)
+
+```yaml
+sphinx:
+  config:
+    proof_uniform_numbering: true
+```

--- a/docs/source/options.md
+++ b/docs/source/options.md
@@ -32,7 +32,7 @@ sphinx:
 Add `proof_minimal_theme = True` to your `conf.py`
 
 
-## Shared numbering 
+## Shared numbering
 
 By default, each type of theorem has their own numbering and counter.
 This can be changed to a common counter by setting the option `proof_uniform_numbering` to true.

--- a/sphinx_proof/__init__.py
+++ b/sphinx_proof/__init__.py
@@ -78,7 +78,6 @@ def copy_asset_files(app: Sphinx, exc: Union[bool, Exception]):
             copy_asset(path, str(Path(app.outdir).joinpath("_static").absolute()))
 
 
-
 realtyp_to_countertyp = {
     "axiom": "axiom",
     "theorem": "theorem",
@@ -96,7 +95,6 @@ realtyp_to_countertyp = {
     "assumption": "assumption",
     "notation": "notation",
 }
-
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/sphinx_proof/__init__.py
+++ b/sphinx_proof/__init__.py
@@ -78,7 +78,6 @@ def copy_asset_files(app: Sphinx, exc: Union[bool, Exception]):
             copy_asset(path, str(Path(app.outdir).joinpath("_static").absolute()))
 
 
-
 def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value("proof_minimal_theme", False, "html")

--- a/sphinx_proof/__init__.py
+++ b/sphinx_proof/__init__.py
@@ -78,10 +78,31 @@ def copy_asset_files(app: Sphinx, exc: Union[bool, Exception]):
             copy_asset(path, str(Path(app.outdir).joinpath("_static").absolute()))
 
 
+
+realtyp_to_countertyp = {
+    "axiom": "axiom",
+    "theorem": "theorem",
+    "lemma": "lemma",
+    "algorithm": "algorithm",
+    "definition": "definition",
+    "remark": "remark",
+    "conjecture": "conjecture",
+    "corollary": "corollary",
+    "criterion": "criterion",
+    "example": "example",
+    "property": "property",
+    "observation": "observation",
+    "proposition": "proposition",
+    "assumption": "assumption",
+    "notation": "notation",
+}
+
+
+
 def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value("proof_minimal_theme", False, "html")
-    app.add_config_value("proof_uniform_numbering", False, "env")
+    app.add_config_value("prf_realtyp_to_countertyp", realtyp_to_countertyp, "env")
 
     app.add_css_file("proof.css")
     app.connect("build-finished", copy_asset_files)

--- a/sphinx_proof/__init__.py
+++ b/sphinx_proof/__init__.py
@@ -81,7 +81,7 @@ def copy_asset_files(app: Sphinx, exc: Union[bool, Exception]):
 def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value("proof_minimal_theme", False, "html")
-    app.add_config_value("prf_realtyp_to_countertyp", {}, "env")
+    app.add_config_value("prf_realtyp_to_countertyp", {}, "html")
 
     app.add_css_file("proof.css")
     app.connect("build-finished", copy_asset_files)

--- a/sphinx_proof/__init__.py
+++ b/sphinx_proof/__init__.py
@@ -78,29 +78,11 @@ def copy_asset_files(app: Sphinx, exc: Union[bool, Exception]):
             copy_asset(path, str(Path(app.outdir).joinpath("_static").absolute()))
 
 
-realtyp_to_countertyp = {
-    "axiom": "axiom",
-    "theorem": "theorem",
-    "lemma": "lemma",
-    "algorithm": "algorithm",
-    "definition": "definition",
-    "remark": "remark",
-    "conjecture": "conjecture",
-    "corollary": "corollary",
-    "criterion": "criterion",
-    "example": "example",
-    "property": "property",
-    "observation": "observation",
-    "proposition": "proposition",
-    "assumption": "assumption",
-    "notation": "notation",
-}
-
 
 def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value("proof_minimal_theme", False, "html")
-    app.add_config_value("prf_realtyp_to_countertyp", realtyp_to_countertyp, "env")
+    app.add_config_value("prf_realtyp_to_countertyp", {}, "env")
 
     app.add_css_file("proof.css")
     app.connect("build-finished", copy_asset_files)

--- a/sphinx_proof/__init__.py
+++ b/sphinx_proof/__init__.py
@@ -81,6 +81,7 @@ def copy_asset_files(app: Sphinx, exc: Union[bool, Exception]):
 def setup(app: Sphinx) -> Dict[str, Any]:
 
     app.add_config_value("proof_minimal_theme", False, "html")
+    app.add_config_value("proof_uniform_numbering", False, "env")
 
     app.add_css_file("proof.css")
     app.connect("build-finished", copy_asset_files)

--- a/sphinx_proof/directive.py
+++ b/sphinx_proof/directive.py
@@ -20,7 +20,6 @@ from .nodes import proof_node
 logger = logging.getLogger(__name__)
 
 
-
 DEFAULT_REALTYP_TO_COUNTERTYP = {
     "axiom": "axiom",
     "theorem": "theorem",
@@ -40,7 +39,6 @@ DEFAULT_REALTYP_TO_COUNTERTYP = {
 }
 
 
-
 class ElementDirective(SphinxDirective):
     """A custom Sphinx Directive"""
 
@@ -58,7 +56,9 @@ class ElementDirective(SphinxDirective):
     def run(self) -> List[Node]:
         env = self.env
         realtyp = self.name.split(":")[1]
-        countertyp = env.config.prf_realtyp_to_countertyp.get(realtyp, DEFAULT_REALTYP_TO_COUNTERTYP[realtyp])
+        countertyp = env.config.prf_realtyp_to_countertyp.get(
+            realtyp, DEFAULT_REALTYP_TO_COUNTERTYP[realtyp]
+        )
         serial_no = env.new_serialno()
         if not hasattr(env, "proof_list"):
             env.proof_list = {}

--- a/sphinx_proof/directive.py
+++ b/sphinx_proof/directive.py
@@ -20,6 +20,27 @@ from .nodes import proof_node
 logger = logging.getLogger(__name__)
 
 
+
+DEFAULT_REALTYP_TO_COUNTERTYP = {
+    "axiom": "axiom",
+    "theorem": "theorem",
+    "lemma": "lemma",
+    "algorithm": "algorithm",
+    "definition": "definition",
+    "remark": "remark",
+    "conjecture": "conjecture",
+    "corollary": "corollary",
+    "criterion": "criterion",
+    "example": "example",
+    "property": "property",
+    "observation": "observation",
+    "proposition": "proposition",
+    "assumption": "assumption",
+    "notation": "notation",
+}
+
+
+
 class ElementDirective(SphinxDirective):
     """A custom Sphinx Directive"""
 
@@ -37,7 +58,7 @@ class ElementDirective(SphinxDirective):
     def run(self) -> List[Node]:
         env = self.env
         realtyp = self.name.split(":")[1]
-        countertyp = env.config.prf_realtyp_to_countertyp[realtyp]
+        countertyp = env.config.prf_realtyp_to_countertyp.get(realtyp, DEFAULT_REALTYP_TO_COUNTERTYP[realtyp])
         serial_no = env.new_serialno()
         if not hasattr(env, "proof_list"):
             env.proof_list = {}

--- a/sphinx_proof/directive.py
+++ b/sphinx_proof/directive.py
@@ -37,9 +37,7 @@ class ElementDirective(SphinxDirective):
     def run(self) -> List[Node]:
         env = self.env
         realtyp = self.name.split(":")[1]
-        countertyp = realtyp
-        if env.config.proof_uniform_numbering:
-            countertyp = "theorem"
+        countertyp = env.config.prf_realtyp_to_countertyp[realtyp]
         serial_no = env.new_serialno()
         if not hasattr(env, "proof_list"):
             env.proof_list = {}

--- a/sphinx_proof/directive.py
+++ b/sphinx_proof/directive.py
@@ -97,7 +97,7 @@ class ElementDirective(SphinxDirective):
         env.proof_list[label] = {
             "docname": env.docname,
             "countertype": countertyp,
-            "realtype" : realtyp,
+            "realtype": realtyp,
             "ids": ids,
             "label": label,
             "prio": 0,

--- a/sphinx_proof/directive.py
+++ b/sphinx_proof/directive.py
@@ -119,16 +119,16 @@ class ProofDirective(SphinxDirective):
     }
 
     def run(self) -> List[Node]:
-        typ = self.name.split(":")[1]
+        realtyp = self.name.split(":")[1]
 
         # If class in options add to class array
-        classes, class_name = ["proof", typ], self.options.get("class", [])
+        classes, class_name = ["proof", realtyp], self.options.get("class", [])
         if class_name:
             classes.extend(class_name)
 
-        section = nodes.admonition(classes=classes, ids=[typ])
+        section = nodes.admonition(classes=classes, ids=[realtyp])
 
-        self.content[0] = "{}. ".format(typ.title()) + self.content[0]
+        self.content[0] = "{}. ".format(realtyp.title()) + self.content[0]
         self.state.nested_parse(self.content, 0, section)
 
         node = proof_node()

--- a/sphinx_proof/domain.py
+++ b/sphinx_proof/domain.py
@@ -161,7 +161,9 @@ class ProofDomain(Domain):
                     number = ".".join(
                         map(str, env.toc_fignumbers[todocname][countertyp][target])
                     )
-                title = nodes.Text(f"{translate(match['countertype'].title())} {number}")
+                title = nodes.Text(
+                    f"{translate(match['countertype'].title())} {number}"
+                )
             # builder, fromdocname, todocname, targetid, child, title=None
             return make_refnode(builder, fromdocname, todocname, target, title)
         else:

--- a/sphinx_proof/domain.py
+++ b/sphinx_proof/domain.py
@@ -162,7 +162,7 @@ class ProofDomain(Domain):
                         map(str, env.toc_fignumbers[todocname][countertyp][target])
                     )
                 title = nodes.Text(
-                    f"{translate(match['countertype'].title())} {number}"
+                    f"{translate(match["realtype"].title())} {number}"
                 )
             # builder, fromdocname, todocname, targetid, child, title=None
             return make_refnode(builder, fromdocname, todocname, target, title)

--- a/sphinx_proof/domain.py
+++ b/sphinx_proof/domain.py
@@ -45,7 +45,7 @@ class ProofIndex(Index):
             return content, True
 
         proofs = self.domain.env.proof_list
-        # {'theorem-0': {'docname': 'start/overview', 'type': 'theorem', 'ids': ['theorem-0'], 'label': 'theorem-0', 'prio': 0, 'nonumber': False}} # noqa: E501
+        # {'theorem-0': {'docname': 'start/overview', 'realtype': 'theorem', 'countertype': 'theorem', 'ids': ['theorem-0'], 'label': 'theorem-0', 'prio': 0, 'nonumber': False}} # noqa: E501
 
         # name, subtype, docname, typ, anchor, extra, qualifier, description
         for anchor, values in proofs.items():
@@ -57,7 +57,7 @@ class ProofIndex(Index):
                     anchor,
                     values["docname"],
                     "",
-                    values["type"],
+                    values["realtype"],
                 )
             )
 
@@ -157,11 +157,11 @@ class ProofDomain(Domain):
             if target in contnode[0]:
                 number = ""
                 if not env.proof_list[target]["nonumber"]:
-                    typ = env.proof_list[target]["type"]
+                    countertyp = env.proof_list[target]["countertype"]
                     number = ".".join(
-                        map(str, env.toc_fignumbers[todocname][typ][target])
+                        map(str, env.toc_fignumbers[todocname][countertyp][target])
                     )
-                title = nodes.Text(f"{translate(match['type'].title())} {number}")
+                title = nodes.Text(f"{translate(match['countertype'].title())} {number}")
             # builder, fromdocname, todocname, targetid, child, title=None
             return make_refnode(builder, fromdocname, todocname, target, title)
         else:

--- a/sphinx_proof/domain.py
+++ b/sphinx_proof/domain.py
@@ -161,9 +161,7 @@ class ProofDomain(Domain):
                     number = ".".join(
                         map(str, env.toc_fignumbers[todocname][countertyp][target])
                     )
-                title = nodes.Text(
-                    f"{translate(match["realtype"].title())} {number}"
-                )
+                title = nodes.Text(f"{translate(match["realtype"].title())} {number}")
             # builder, fromdocname, todocname, targetid, child, title=None
             return make_refnode(builder, fromdocname, todocname, target, title)
         else:

--- a/sphinx_proof/nodes.py
+++ b/sphinx_proof/nodes.py
@@ -15,6 +15,7 @@ from sphinx.locale import get_translation
 
 
 from sphinx.util import logging
+
 logger = logging.getLogger(__name__)
 
 MESSAGE_CATALOG_NAME = "proof"
@@ -36,7 +37,7 @@ def visit_enumerable_node(self, node: Node) -> None:
 
 def depart_enumerable_node(self, node: Node) -> None:
     countertyp = node.attributes.get("countertype", "")
-    realtyp= node.attributes.get("realtype", "")
+    realtyp = node.attributes.get("realtype", "")
     if isinstance(self, LaTeXTranslator):
         number = get_node_number(self, node, countertyp)
         idx = list_rindex(self.body, latex_admonition_start) + 2

--- a/sphinx_proof/nodes.py
+++ b/sphinx_proof/nodes.py
@@ -13,6 +13,10 @@ from docutils.nodes import Node
 from sphinx.writers.latex import LaTeXTranslator
 from sphinx.locale import get_translation
 
+
+from sphinx.util import logging
+logger = logging.getLogger(__name__)
+
 MESSAGE_CATALOG_NAME = "proof"
 _ = get_translation(MESSAGE_CATALOG_NAME)
 
@@ -31,17 +35,18 @@ def visit_enumerable_node(self, node: Node) -> None:
 
 
 def depart_enumerable_node(self, node: Node) -> None:
-    typ = node.attributes.get("type", "")
+    countertyp = node.attributes.get("countertype", "")
+    realtyp= node.attributes.get("realtype", "")
     if isinstance(self, LaTeXTranslator):
-        number = get_node_number(self, node, typ)
+        number = get_node_number(self, node, countertyp)
         idx = list_rindex(self.body, latex_admonition_start) + 2
-        self.body.insert(idx, f"{typ.title()} {number}")
+        self.body.insert(idx, f"{realtyp.title()} {number}")
         self.body.append(latex_admonition_end)
     else:
         # Find index in list of 'Proof #'
-        number = get_node_number(self, node, typ)
-        idx = self.body.index(f"{typ} {number} ")
-        self.body[idx] = f"{_(typ.title())} {number} "
+        number = get_node_number(self, node, countertyp)
+        idx = self.body.index(f"{countertyp} {number} ")
+        self.body[idx] = f"{_(realtyp.title())} {number} "
         self.body.append("</div>")
 
 
@@ -79,10 +84,10 @@ def depart_proof_node(self, node: Node) -> None:
     pass
 
 
-def get_node_number(self, node: Node, typ) -> str:
+def get_node_number(self, node: Node, countertyp) -> str:
     """Get the number for the directive node for HTML."""
     ids = node.attributes.get("ids", [])[0]
-    key = typ
+    key = countertyp
     if isinstance(self, LaTeXTranslator):
         docname = find_parent(self.builder.env, node, "section")
         fignumbers = self.builder.env.toc_fignumbers.get(
@@ -91,7 +96,7 @@ def get_node_number(self, node: Node, typ) -> str:
     else:
         fignumbers = self.builder.fignumbers
         if self.builder.name == "singlehtml":
-            key = "%s/%s" % (self.docnames[-1], typ)
+            key = "%s/%s" % (self.docnames[-1], countertyp)
     number = fignumbers.get(key, {}).get(ids, ())
     return ".".join(map(str, number))
 

--- a/sphinx_proof/nodes.py
+++ b/sphinx_proof/nodes.py
@@ -60,18 +60,18 @@ def visit_unenumerable_node(self, node: Node) -> None:
 
 
 def depart_unenumerable_node(self, node: Node) -> None:
-    typ = node.attributes.get("type", "")
+    realtyp = node.attributes.get("realtype", "")
     title = node.attributes.get("title", "")
     if isinstance(self, LaTeXTranslator):
         idx = list_rindex(self.body, latex_admonition_start) + 2
-        self.body.insert(idx, f"{typ.title()}")
+        self.body.insert(idx, f"{realtyp.title()}")
         self.body.append(latex_admonition_end)
     else:
         if title == "":
             idx = list_rindex(self.body, '<p class="admonition-title">') + 1
         else:
             idx = list_rindex(self.body, title)
-        element = f"<span>{_(typ.title())} </span>"
+        element = f"<span>{_(realtyp.title())} </span>"
         self.body.insert(idx, element)
         self.body.append("</div>")
 


### PR DESCRIPTION
This PR is an attempt to resolve issue #64 . 
This is done by adding a configuration variable `proof_uniform_numbering`. When it is set to true all numbered proof environments share a counter.

under the hood I have split the `type` parameter of the node into who parameters, `countertype` and `realtye`. 
In the default setting, those two agree.
When `proof_uniform_numbering = True` is set in `conf.py`, then the `countertype` of all objects is `theorem`, i.e. they all share the same counter.

`pytest` seems to pass, and the uniformly numbered version seems to work fine on the docs.
However, I don't really know how to write python tests, so I could not add tests for the new version.
